### PR TITLE
Test translation functionality before deployment

### DIFF
--- a/.github/workflows/f24_nodebb-csc-translator-service.yml
+++ b/.github/workflows/f24_nodebb-csc-translator-service.yml
@@ -33,6 +33,10 @@ jobs:
       # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
       - name: Zip artifact for deployment
         run: zip release.zip ./* -r
+      
+      - name: Test with pytest
+        run: |
+          pytest
 
       - name: Upload artifact for deployment jobs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow for the `f24_nodebb-csc-translator-service` project. The change adds a step to run tests using `pytest` before uploading the artifact for deployment.

* [`.github/workflows/f24_nodebb-csc-translator-service.yml`](diffhunk://#diff-22e0ae795d4a21bfd6f67cfa33192062c5de6cbe2312aa153d36cfbb00ec7cb5R37-R40): Added a new step to run `pytest` tests before the artifact upload step.